### PR TITLE
assigned URL to KEYCLOAK_MASTER_REALM_URL because it was pointing to …

### DIFF
--- a/gloo-edge/gloo-edge/README.md
+++ b/gloo-edge/gloo-edge/README.md
@@ -1071,6 +1071,13 @@ You can see that the `jwt` header has been added to the request while the cookie
 
 JWKS is a set of public keys that can be used to verify the JWT tokens.
 
+First, we need to assign the value to a variable of the keycloak master realm.   
+
+```
+KEYCLOAK_MASTER_REALM_URL=http://$(kubectl get svc keycloak -ojsonpath='{.status.loadBalancer.ingress[0].ip}'):8080/auth/realms/master
+```
+
+
 Now, we can update the Virtual Service to validate the token, extract claims from the token and create new headers based on these claims.
 
 ```bash
@@ -1111,7 +1118,7 @@ spec:
       jwt:
         providers:
           dex:
-            issuer: http://172.18.1.2:8080/auth/realms/master
+            issuer: ${KEYCLOAK_MASTER_REALM_URL}
             tokenSource:
               headers:
               - header: Jwt
@@ -1215,7 +1222,7 @@ spec:
       jwt:
         providers:
           dex:
-            issuer: http://172.18.1.2:8080/auth/realms/master
+            issuer: ${KEYCLOAK_MASTER_REALM_URL}
             tokenSource:
               headers:
               - header: Jwt


### PR DESCRIPTION
In preparing for Wednesday's Gloo Edge workshop I noticed a bit of drift concerning the keycloak issuer url for the last 2 labs. 

For the labs:
- https://github.com/solo-io/workshops/tree/master/gloo-edge/gloo-edge#extract-information-from-the-jwt-token
- https://github.com/solo-io/workshops/tree/master/gloo-edge/gloo-edge#rbac-using-the-claims-of-the-jwt-token

The `spec.virtualHost.options.jwt.providers.dex.issuer` url was pointing to a URL that does not exist. 

I was getting the error `jwt issuer is not configured`

A variable `KEYCLOAK_MASTER_REALM_URL` needed to be created to point the issuer url to the loadBalancer of keycloak where the public keys for the master realm exist.