### PR TITLE
update address to curl against

### DIFF
--- a/gloo-portal/README.md
+++ b/gloo-portal/README.md
@@ -1364,7 +1364,7 @@ token=$(curl -d "client_id=admin-cli" -d "username=user1" -d "password=password"
 Then, we can run the following command:
 
 ```
-./grpcurl -plaintext -H "Authorization: Bearer ${token}" -authority dev.petstore.com 172.18.1.2:80 test.solo.io.PetStore/ListPets
+./grpcurl -plaintext -H "Authorization: Bearer ${token}" -authority dev.petstore.com $(glooctl proxy url | cut -c 8-) test.solo.io.PetStore/ListPets
 ```
 
 You should get a result similar to:


### PR DESCRIPTION
This command did not seem to be working on a mac:

```
./grpcurl -plaintext -H "Authorization: Bearer ${token}" -authority dev.petstore.com 172.18.1.2:80 test.solo.io.PetStore/ListPets
```

so i changed the `172.18.1.2:80` to `$(glooctl proxy url | cut -c 8-) ` and it worked. 