### PR TITLE
updated istio-system to istio-ingress in text

### DIFF
--- a/istio-day2/1-deploy-istio/04-ingress-gateway.md
+++ b/istio-day2/1-deploy-istio/04-ingress-gateway.md
@@ -321,7 +321,7 @@ Let's try call our gateway again to make sure the call still succeeds:
 curl --cacert ./labs/04/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP
 ```
 
-In this section, we created the `Certificate` in the `istio-system` namespace. But if we don't have access to that namespace, what else could we do?
+In this section, we created the `Certificate` in the `istio-ingress` namespace. But if we don't have access to that namespace, what else could we do?
 
 ## Reduce Gateway Config for large meshes
 


### PR DESCRIPTION
The original text says:
```
In this section, we created the `Certificate` in the `istio-system` namespace. But if we don't have access to that namespace, what else could we do?
```
but we created the cert in the `istio-ingress` namespace.