### PR TITLE
Remove route

### DIFF
--- a/istio-day2/1-deploy-istio/labs/07/vs-delegate.yaml
+++ b/istio-day2/1-deploy-istio/labs/07/vs-delegate.yaml
@@ -15,7 +15,6 @@ spec:
     delegate:
       name: helloworld
       namespace: default
-  - route:
-    delegate:
+  - delegate:
       name: web-api-gw-vs
       namespace: istioinaction


### PR DESCRIPTION
Manifest throws an error since `route` expects an array.
https://istio.io/v1.8/docs/reference/config/networking/virtual-service/#HTTPRouteDestination
