### PR TITLE
apiversion-fix

### DIFF
--- a/istio-day2/1-deploy-istio/labs/04/ingress-gw-access-logging.yaml
+++ b/istio-day2/1-deploy-istio/labs/04/ingress-gw-access-logging.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-access-logging

--- a/istio-day2/1-deploy-istio/labs/05/web-api-access-logging.yaml
+++ b/istio-day2/1-deploy-istio/labs/05/web-api-access-logging.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: web-api-access-logging

--- a/istio-day2/1-deploy-istio/labs/06/web-api-access-logging-audit.yaml
+++ b/istio-day2/1-deploy-istio/labs/06/web-api-access-logging-audit.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: web-api-access-log

--- a/istio-day2/1-deploy-istio/labs/06/web-api-access-logging.yaml
+++ b/istio-day2/1-deploy-istio/labs/06/web-api-access-logging.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: web-api-access-log


### PR DESCRIPTION
kubectl get crd envoyfilters.networking.istio.io -o yaml |yq -j eval|jq '.spec.versions[].name'

NO VERSION BETA1 FOR ENVOYFILTERS!!