### PR TITLE
Workshop automation

### DIFF
--- a/istio-basics/01-install-istio.md
+++ b/istio-basics/01-install-istio.md
@@ -16,7 +16,11 @@ Add istioctl client to your path:
 cd istio-1.10.0
 export PATH=$PWD/bin:$PATH
 ```
-
+<!--bash
+pushd /usr/local/bin
+  ln -s $(which istioctl)
+popd
+-->
 Check istioctl version:
 
 ```bash
@@ -46,14 +50,16 @@ istioctl install --set profile=demo -y
 {% hint style="info" %}
 If your Kubernetes environment can only support Kubernetes Service of type `NodePort`, configure your Istio ingress gateway to use type `NodePort`
 
-```bash
+```
 istioctl install --set profile=demo -y --set values.gateways.istio-ingressgateway.type=NodePort
 ```
 
 {% endhint %}
 
 Check out the resources installed by Istio:
-
+<!--bash
+kubectl wait --for=condition=Ready pod --all -n istio-system
+-->
 ```bash
 kubectl get all,cm,secrets -n istio-system
 ```
@@ -67,7 +73,7 @@ kubectl get crds -n istio-system
 Check out Istio resources installed by Istio and used by Istio internally:
 
 ```bash
-kubectl get istio-io -n istio-system
+istioctl verify-install
 ```
 
 ## Install Istio Telemetry Addons
@@ -77,7 +83,9 @@ Istio telemetry addons are shipped as samples because these addons are optimized
 ```bash
 kubectl apply -f samples/addons
 ```
-
+<!--bash
+kubectl wait --for=condition=Ready pod --all -n istio-system
+-->
 If you hit an error like below, rerun the above command to ensure the `samples/addons` are applied to your Kubernetes cluster. The error below could happen when you attempt to install any `MonitoringDashboard` custom resource before the `MonitoringDashboard` custom resource definition (CRD) is installed.
 
 ```
@@ -86,25 +94,25 @@ unable to recognize "samples/addons/kiali.yaml": no matches for kind "Monitoring
 
 Verify you can access the Prometheus dashboard:
 
-```bash
+```
 istioctl dashboard prometheus
 ```
 
 Verify you can access the Grafana dashboard:
 
-```bash
+```
 istioctl dashboard grafana
 ```
 
 Verify you can access the Jaeger dashboard:
 
-```bash
+```
 istioctl dashboard jaeger
 ```
 
 Verify you can access the Kiali dashboard:
 
-```bash
+```
 istioctl dashboard kiali
 ```
 

--- a/istio-basics/04-secure-services-with-istio.md
+++ b/istio-basics/04-secure-services-with-istio.md
@@ -52,15 +52,17 @@ kubectl apply -n default -f sample-apps/sleep.yaml
 ```
 
 Access the `web-api` service from the `sleep` pod in the default namespace:
-
+<!--bash
+kubectl wait --for=condition=Ready pod -n default --all
+-->
 ```bash
-kubectl exec -it deploy/sleep -n default -- curl http://web-api.istioinaction:8080/
+kubectl exec deploy/sleep -n default -- curl http://web-api.istioinaction:8080/
 ```
 
 The request will fail because the `web-api` service can only be accessed with mutual TLS. The `sleep` pod in the default namespace doesn't have the sidecar proxy so it doesn't have the needed keys and certificates to communicate to the `web-api` service via mutual TLS.  Run the same command from the `sleep` pod in the `istioinaction` namespace:
 
 ```bash
-kubectl exec -it deploy/sleep -n istioinaction -- curl http://web-api.istioinaction:8080/
+kubectl exec deploy/sleep -n istioinaction -- curl http://web-api.istioinaction:8080/
 ```
 
 You should see the request succeed.
@@ -71,7 +73,7 @@ Question: How can you check if a service or namespace is ready to enable the `ST
 
 You can visualize the services in the mesh in Kiali.  Launch Kiali using the command below:
 
-```bash
+```
 istioctl dashboard kiali
 ```
 
@@ -79,9 +81,18 @@ Navigate to [http://localhost:20001](http://localhost:20001) and select the Grap
 
 On the "Namespace" dropdown, select "istioinaction". On the "Display" drop down, select "Traffic Animation" and "Security". Let's also generate some load to the data plane (by calling our `web-api` service) so that you can observe interactions among your services:
 
-```bash
+<!--bash
+GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+SECURE_INGRESS_PORT=443
 for i in {1..200}; 
-  do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP;
+  do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT  --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP;
+  echo "$i/200"
+done
+-->
+
+```
+for i in {1..200}; 
+  do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT  --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP;
   sleep 1;
 done
 ```

--- a/istio-basics/05-control-traffic.md
+++ b/istio-basics/05-control-traffic.md
@@ -122,7 +122,9 @@ kubectl apply -f labs/05/purchase-history-v2.yaml -n istioinaction
 ```
 
 Confirm the new v2 `purchase-history` pod has reached running:
-
+<!--bash
+kubectl wait --for=condition=Ready pod -l app=purchase-history -n istioinaction
+-->
 ```bash
 kubectl get pods -n istioinaction -l app=purchase-history
 ```
@@ -136,9 +138,12 @@ purchase-history-v2-74886f799f-lgzfn   2/2     Running   0          4m
 ```
 
 Generate some load on the `web-api` service to ensure your users are not impacted by deploying of the v2 of the `purchase-history` service:
-
+<!--bash
+GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+SECURE_INGRESS_PORT=443
+-->
 ```bash
-for i in {1..10}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP|grep "Hello From Purchase History"; done
+for i in {1..10}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP|grep "Hello From Purchase History"; done
 ```
 
 You will see all of the 10 responses from `purchase-history` are from v1 of the service.  This is great!  We introduced v2 of the service but it didn't impact any of the behavior of the existing requests.  Next, let us test the v2 of the service:
@@ -230,7 +235,9 @@ kubectl apply -f labs/05/purchase-history-v2-updated.yaml -n istioinaction
 ```
 
 Test the v2 service:
-
+<!--bash
+sleep 2
+-->
 ```bash
 kubectl exec deploy/purchase-history-v2 -n istioinaction -c istio-proxy -- curl localhost:8080
 ```
@@ -300,8 +307,11 @@ kubectl apply -f labs/05/purchase-history-vs-20-v2.yaml -n istioinaction
 
 Generate some load on the `web-api` service to check how many requests are served by v1 and v2 of the `purchase-history` service. You should see only a few from v2 while the rest from v1. You may be curious why you are not observe an exactly 80%/20% distribution among v1 and v2.  You likely need to have over 100 requests to get the desired 80%/20% weighted version distribution.
 
+<!--bash
+sleep 2
+-->
 ```bash
-for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP|grep "Hello From Purchase History"; done
+for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP|grep "Hello From Purchase History"; done
 ```
 
 ### Shift 50% Traffic to v2
@@ -346,8 +356,11 @@ kubectl apply -f labs/05/purchase-history-vs-50-v2.yaml -n istioinaction
 
 Generate some load on the `web-api` service to check how many requests are served by v1 and v2 of the `purchase-history` service. You should observe *roughly* 50%/50% distribution among the v1 and v2 of the service.
 
+<!--bash
+sleep 2
+-->
 ```bash
-for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP|grep "Hello From Purchase History"; done
+for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP|grep "Hello From Purchase History"; done
 ```
 
 ### Shift All Traffic to v2
@@ -361,8 +374,11 @@ kubectl apply -f labs/05/purchase-history-vs-all-v2.yaml -n istioinaction
 
 Generate some load on the `web-api` service, you should only see traffic to the v2 of the `purchase-history` service.
 
+<!--bash
+sleep 2
+-->
 ```bash
-for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP|grep "Hello From Purchase History"; done
+for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP|grep "Hello From Purchase History"; done
 ```
 
 ## Resiliency and Chaos Testing

--- a/istio-basics/labs/01/check.sh
+++ b/istio-basics/labs/01/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ "x$?" != "x0" ]; then echo FAIL: "\"${last_command}\" command failed"; fi' EXIT
+
+istioctl version
+istioctl verify-install

--- a/istio-basics/labs/01/cleanup.sh
+++ b/istio-basics/labs/01/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash -le
+
+istioctl x uninstall --purge -y
+kubectl delete ns istio-system

--- a/istio-basics/labs/01/solve.sh
+++ b/istio-basics/labs/01/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+INSTRUCTIONS_FILE="01-install-istio.md"
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  cat "${INSTRUCTIONS_FILE}" | "../md-to-bash.sh" |bash
+popd

--- a/istio-basics/labs/02/check.sh
+++ b/istio-basics/labs/02/check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash -le
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ "x$?" != "x0" ]; then echo FAIL: "\"${last_command}\" command failed"; fi' EXIT
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  SECURE_INGRESS_PORT=443
+  curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP
+  curl -H "Host: istioinaction.io" http://istioinaction.io --resolve istioinaction.io:80:$GATEWAY_IP 2> /tmp/capture.out || true
+  cat /tmp/capture.out | grep "Connection refused"
+popd

--- a/istio-basics/labs/02/cleanup.sh
+++ b/istio-basics/labs/02/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash -le
+
+kubectl delete ns istioinaction
+kubectl delete secret/istioinaction-cert -n istio-system

--- a/istio-basics/labs/02/script.sh
+++ b/istio-basics/labs/02/script.sh
@@ -28,7 +28,7 @@ kubectl -n istioinaction apply -f labs/02/web-api-gw-https.yaml
 
 sleep 5
 
-curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP
+curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP
 
 echo "This should fail"
 curl -H "Host: istioinaction.io" http://$GATEWAY_IP

--- a/istio-basics/labs/02/solve.sh
+++ b/istio-basics/labs/02/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+INSTRUCTIONS_FILE="02-secure-service-ingress.md"
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  cat "${INSTRUCTIONS_FILE}" | "../md-to-bash.sh" |bash
+popd

--- a/istio-basics/labs/02/web-api-gw-https.yaml
+++ b/istio-basics/labs/02/web-api-gw-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: web-api-gateway

--- a/istio-basics/labs/03/check.sh
+++ b/istio-basics/labs/03/check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash -le
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ "x$?" != "x0" ]; then echo FAIL: "\"${last_command}\" command failed"; fi' EXIT
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  SECURE_INGRESS_PORT=443
+  curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP
+  istioctl ps deploy/web-api -n istioinaction
+  istioctl ps deploy/purchase-history-v1 -n istioinaction
+  istioctl ps deploy/recommendation -n istioinaction
+  istioctl ps deploy/sleep -n istioinaction
+popd

--- a/istio-basics/labs/03/cleanup.sh
+++ b/istio-basics/labs/03/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash -le
+
+kubectl label namespace istioinaction istio-injection-
+kubectl rollout restart deployment web-api -n istioinaction
+kubectl rollout restart deployment purchase-history-v1 -n istioinaction
+kubectl rollout restart deployment recommendation -n istioinaction
+kubectl rollout restart deployment sleep -n istioinaction

--- a/istio-basics/labs/03/script.sh
+++ b/istio-basics/labs/03/script.sh
@@ -11,7 +11,7 @@ kubectl get pod -l app=web-api -n istioinaction
 kubectl logs deploy/web-api -c web-api -n istioinaction
 
 GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP
+curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP
 
 kubectl get pod -l app=web-api -n istioinaction -o yaml
 
@@ -21,5 +21,5 @@ kubectl rollout restart deployment purchase-history-v1 -n istioinaction
 kubectl rollout restart deployment recommendation -n istioinaction
 kubectl rollout restart deployment sleep -n istioinaction
 
-for i in {1..10}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io --resolve istioinaction.io:443:$GATEWAY_IP; done
+for i in {1..10}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT  --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP; done
 

--- a/istio-basics/labs/03/solve.sh
+++ b/istio-basics/labs/03/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+INSTRUCTIONS_FILE="03-add-services-to-mesh.md"
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  cat "${INSTRUCTIONS_FILE}" | "../md-to-bash.sh" |bash
+popd

--- a/istio-basics/labs/04/check.sh
+++ b/istio-basics/labs/04/check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash -le
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ "x$?" != "x0" ]; then echo FAIL: "\"${last_command}\" command failed"; fi' EXIT
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  kubectl get peerauthentication --all-namespaces|grep STRICT
+  GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  SECURE_INGRESS_PORT=443
+  curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP
+popd

--- a/istio-basics/labs/04/cleanup.sh
+++ b/istio-basics/labs/04/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash -le
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  kubectl delete -n default -f sample-apps/sleep.yaml
+  kubectl delete PeerAuthentication default -n istio-system
+popd

--- a/istio-basics/labs/04/solve.sh
+++ b/istio-basics/labs/04/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+INSTRUCTIONS_FILE="04-secure-services-with-istio.md"
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  cat "${INSTRUCTIONS_FILE}" | "../md-to-bash.sh" |bash
+popd

--- a/istio-basics/labs/05/check.sh
+++ b/istio-basics/labs/05/check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash -le
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ "x$?" != "x0" ]; then echo FAIL: "\"${last_command}\" command failed"; fi' EXIT
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  GATEWAY_IP=$(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  SECURE_INGRESS_PORT=443
+  for i in {1..20}; do curl --cacert ./labs/02/certs/ca/root-ca.crt -H "Host: istioinaction.io" https://istioinaction.io:$SECURE_INGRESS_PORT --resolve istioinaction.io:$SECURE_INGRESS_PORT:$GATEWAY_IP|grep "Hello From Purchase History (v2)"; done
+popd

--- a/istio-basics/labs/05/cleanup.sh
+++ b/istio-basics/labs/05/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  kubectl delete -f labs/05/purchase-history-vs-all-v1.yaml -n istioinaction
+  kubectl delete -f labs/05/purchase-history-dr.yaml -n istioinaction
+  kubectl delete -f labs/05/purchase-history-v2.yaml -n istioinaction
+popd

--- a/istio-basics/labs/05/solve.sh
+++ b/istio-basics/labs/05/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -le
+
+INSTRUCTIONS_FILE="05-control-traffic.md"
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+pushd "$SCRIPTDIR/../.."
+  cat "${INSTRUCTIONS_FILE}" | "../md-to-bash.sh" |bash
+popd


### PR DESCRIPTION
+ Compatibility with `md-to-bash.sh`
+ Added check.sh, cleanup.sh, solve.sh to all 5 labs
+ NodePort mode is now compatible with all labs, making `$INGRESS_PORT` and `$SECURE_INGRESS_PORT` always a reference
+ Small typo with apiversion