### PR TITLE
Avoid rate limit with many machines at once

### DIFF
--- a/INSTRUCTOR.md
+++ b/INSTRUCTOR.md
@@ -137,13 +137,19 @@ cd terraform
 Run the following command to destroy all the replicas:
 
 ```
-terraform destroy -target=module.vm-replica -force
+terraform destroy -target=module.vm-replica
+```
+
+Run the following command to destroy some replicas:
+
+```
+terraform destroy -target=module.vm-replica[\"myname\"]
 ```
 
 Run the following command to destroy all the source images:
 
 ```
-terraform destroy -target=module.vm-image -force
+terraform destroy -target=module.vm-image
 ```
 
 Run the following command to destroy all:

--- a/terraform/gce/vm-image/main.tf
+++ b/terraform/gce/vm-image/main.tf
@@ -50,8 +50,8 @@ resource "google_compute_instance" "vm" {
 }
 
 resource "google_compute_image" "image" {
-  project      = var.project
-  name = google_compute_instance.vm.name
+  project = var.project
+  name    = google_compute_instance.vm.name
 
   source_disk = "projects/${var.project}/zones/${var.zone}/disks/${google_compute_instance.vm.name}"
 }

--- a/terraform/gce/vm-image/main.tf
+++ b/terraform/gce/vm-image/main.tf
@@ -13,11 +13,6 @@ resource "google_compute_instance" "vm" {
     }
   }
 
-  // Local SSD disk
-  scratch_disk {
-    interface = "SCSI"
-  }
-
   network_interface {
     network = "default"
 
@@ -34,7 +29,6 @@ resource "google_compute_instance" "vm" {
   lifecycle {
     ignore_changes = [
       machine_type,
-      zone,
       tags
     ]
   }
@@ -48,15 +42,16 @@ resource "google_compute_instance" "vm" {
   provisioner "local-exec" {
     command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u solo -i '${self.network_interface.0.access_config.0.nat_ip},' ansible-playbook.yml -v"
   }
+
+  # Stop machine
+  provisioner "local-exec" {
+    command = "gcloud compute instances stop ${self.name} --project ${var.project} --zone ${var.zone}"
+  }
 }
 
-resource "google_compute_machine_image" "image" {
-  provider        = google-beta
-  project         = var.project
-  name            = "${terraform.workspace}-${var.prefix}-source-image"
-  source_instance = google_compute_instance.vm.self_link
+resource "google_compute_image" "image" {
+  project      = var.project
+  name = google_compute_instance.vm.name
 
-  provisioner "local-exec" {
-    command = "gcloud beta compute instances suspend ${self.name} --project ${var.project} --zone ${var.zone} --discard-local-ssd --quiet || true"
-  }
+  source_disk = "projects/${var.project}/zones/${var.zone}/disks/${google_compute_instance.vm.name}"
 }

--- a/terraform/gce/vm-image/outputs.tf
+++ b/terraform/gce/vm-image/outputs.tf
@@ -3,5 +3,5 @@ output "gce_public_ip" {
 }
 
 output "gce_vm_name" {
-  value = google_compute_machine_image.image.id
+  value = google_compute_image.image.name
 }

--- a/terraform/gce/vm-replica/inputs.tf
+++ b/terraform/gce/vm-replica/inputs.tf
@@ -21,3 +21,7 @@ variable "num_instances" {
 variable "source_machine_image" {
   type = string
 }
+
+locals {
+  ssh_file = "./lab.pub"
+}

--- a/terraform/gce/vm-replica/main.tf
+++ b/terraform/gce/vm-replica/main.tf
@@ -1,3 +1,43 @@
+resource "google_compute_instance" "vm" {
+  project      = var.project
+  count    = var.num_instances
+  name         = "${var.source_machine_image}-${count.index + 1}"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  tags = [var.prefix]
+
+  boot_disk {
+    initialize_params {
+      image = var.source_machine_image
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    enable-oslogin = "FALSE"
+    ssh-keys       = "solo:${file(local.ssh_file)}"
+  }
+
+  # Wait until ip is available
+  provisioner "local-exec" {
+    command = "echo 'waiting for ip ${self.network_interface.0.access_config.0.nat_ip}' && until nc -z ${self.network_interface.0.access_config.0.nat_ip} 22; do sleep 1; done && sleep 10"
+  }
+
+  # Provision machine with ansible
+  provisioner "local-exec" {
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u solo -i '${self.network_interface.0.access_config.0.nat_ip},' ansible-playbook.yml -v"
+  }
+
+}
+
 resource "google_compute_firewall" "default" {
   project = var.project
   name    = "${terraform.workspace}-${var.prefix}-firewall"
@@ -14,30 +54,4 @@ resource "google_compute_firewall" "default" {
 
   source_ranges = ["0.0.0.0/0"]
   target_tags   = [var.prefix]
-}
-
-resource "google_compute_instance_from_machine_image" "tpl" {
-  provider = google-beta
-  count    = var.num_instances
-  name     = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
-  zone     = var.zone
-
-  source_machine_image = var.source_machine_image
-
-  // Override fields from machine image
-  project      = var.project
-  machine_type = var.machine_type
-  labels = {
-    source_image = split("/", var.source_machine_image)[4]
-  }
-
-  # Wait until ip is available
-  provisioner "local-exec" {
-    command = "echo 'waiting for ip ${self.network_interface.0.access_config.0.nat_ip}' && until nc -z ${self.network_interface.0.access_config.0.nat_ip} 22; do sleep 1; done && sleep 10"
-  }
-
-  # Provision machine with ansible
-  provisioner "local-exec" {
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u solo -i '${self.network_interface.0.access_config.0.nat_ip},' -e ansible_python_interpreter=/usr/bin/python3 -e reboot_vm=true ansible-playbook.yml -v"
-  }
 }

--- a/terraform/gce/vm-replica/main.tf
+++ b/terraform/gce/vm-replica/main.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "vm" {
   project      = var.project
-  count    = var.num_instances
+  count        = var.num_instances
   name         = "${var.source_machine_image}-${count.index + 1}"
   machine_type = var.machine_type
   zone         = var.zone

--- a/terraform/gce/vm-replica/outputs.tf
+++ b/terraform/gce/vm-replica/outputs.tf
@@ -1,3 +1,3 @@
 output "gce_public_ip" {
-  value = google_compute_instance_from_machine_image.tpl[*].network_interface.0.access_config.0.nat_ip
+  value = google_compute_instance.vm.*.network_interface.0.access_config.0.nat_ip
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,7 @@
 output "workshop_credentials" {
   value = {
-    user: "solo"
-    password: "Workshop1#"
+    user : "solo"
+    password : "Workshop1#"
   }
 }
 


### PR DESCRIPTION
+ Removed use of gcp beta provider and gcp beta commands
+ Removed SSD scratch disk as they were not used (missing step https://cloud.google.com/compute/docs/disks/local-ssd#formatandmount). Anyway, not needed for workshop so wasted money.
+ Machines are now created from DISK IMAGES instead of full VM IMAGES. This process is cleaner and allow more changes in the final machine. In addition, disk images are not affected by ratelimit in the api

* Note: If you have resources from previous versions (using beta providers), please DESTROY your workspace before upgrading, or you will have risk to leave stale resources. If that is your case, delete them manually to avoid extra costs.