### PR TITLE
eks_clusters

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,8 +3,10 @@ hosts
 **/*.tfstate
 *.tfstate.*
 .terraform
+.terraform.lock.hcl
 .env.sh
 env.sh
 ansible-playbook-hack.yml
 hack.sh
 .vagrant
+output

--- a/terraform/aws/eks/inputs.tf
+++ b/terraform/aws/eks/inputs.tf
@@ -1,0 +1,23 @@
+variable "prefix" {
+  type = string
+}
+
+variable "num_instances" {
+  type = string
+}
+
+variable "azs_controlplane" {
+  type = list(string)
+}
+
+variable "azs_workers" {
+  type = list(string)
+}
+
+variable "eks_version" {
+  type = string
+}
+
+variable "node_instance_type" {
+  type = string
+}

--- a/terraform/aws/eks/main.tf
+++ b/terraform/aws/eks/main.tf
@@ -1,0 +1,38 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "v3.1.0"
+  count   = var.num_instances
+
+  name = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
+  cidr = "10.0.0.0/16"
+
+  azs            = var.azs_controlplane
+  public_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+
+  tags = {
+    "kubernetes.io/cluster/${terraform.workspace}-${var.prefix}-${count.index + 1}" = "shared"
+  }
+}
+
+data "aws_subnet_ids" "nodes" {
+  count  = var.num_instances
+  vpc_id = module.vpc[count.index].vpc_id
+  filter {
+    name   = "tag:Name"
+    values = [for str in var.azs_workers : format("*%s", str)]
+  }
+}
+
+module "eks" {
+  source  = "howdio/eks/aws"
+  version = "v2.0.2"
+  count   = var.num_instances
+
+  name               = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
+  vpc_id             = module.vpc[count.index].vpc_id
+  cluster_subnet_ids = flatten([module.vpc[count.index].private_subnets, module.vpc[count.index].public_subnets])
+  node_subnet_ids    = data.aws_subnet_ids.nodes[count.index].ids
+  node_instance_type = var.node_instance_type
+  node_ami_lookup    = "amazon-eks-node-${var.eks_version}*"
+  eks_version        = var.eks_version
+}

--- a/terraform/aws/eks/outputs.tf
+++ b/terraform/aws/eks/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_name" {
+  value = module.eks.*.cluster_name
+}
+
+output "kubeconfig" {
+  value = module.eks.*.kubeconfig
+}

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -10,6 +10,14 @@ variable "zone" {
   type = string
 }
 
+variable "azs_controlplane" {
+  type = list(string)
+}
+
+variable "azs_workers" {
+  type = list(string)
+}
+
 variable "vm_image" {
   type = string
 }
@@ -20,4 +28,16 @@ variable "num_instances" {
 
 variable "environments" {
   type = map(any)
+}
+
+variable "eks_clusters" {
+  type = map(any)
+}
+
+variable "eks_version" {
+  type = string
+}
+
+variable "node_instance_type" {
+  type = string
 }

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -27,11 +27,13 @@ variable "num_instances" {
 }
 
 variable "environments" {
-  type = map(any)
+  type    = map(any)
+  default = {}
 }
 
 variable "eks_clusters" {
-  type = map(any)
+  type    = map(any)
+  default = {}
 }
 
 variable "eks_version" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,3 +20,15 @@ module "vm-replica" {
   num_instances        = lookup(each.value, "num_instances", var.num_instances)
   source_machine_image = module.vm-image[each.key].gce_vm_name
 }
+
+module "eks-cluster" {
+  source   = "./aws/eks"
+  for_each = var.eks_clusters
+
+  prefix             = each.key
+  num_instances      = lookup(each.value, "num_instances", var.num_instances)
+  azs_controlplane   = lookup(each.value, "azs_controlplane", var.azs_controlplane)
+  azs_workers        = lookup(each.value, "azs_workers", var.azs_workers)
+  eks_version        = lookup(each.value, "eks_version", var.eks_version)
+  node_instance_type = lookup(each.value, "node_instance_type", var.node_instance_type)
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -16,3 +16,9 @@ output "gce_replicas_public_ip" {
     for k, v in module.vm-replica : k => v.gce_public_ip
   }
 }
+
+output "eks_cluster" {
+  value = {
+    for k, v in module.eks-cluster : k => v.cluster_name
+  }
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,6 +5,12 @@ zone          = "europe-west4-a"
 vm_image      = "ubuntu-2004-focal-v20210510"
 num_instances = 1
 
+#EKS
+azs_controlplane   = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+azs_workers        = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+eks_version        = "1.20"
+node_instance_type = "t3.small"
+
 # TO BE EDITED #
 environments = {
   #workshop1 = {
@@ -18,3 +24,14 @@ environments = {
     machine_type  = "n1-standard-8"
   }
 }
+
+#eks_clusters = {
+#  workshop-a = {
+#    num_instances = 2
+#    azs_workers   = ["eu-west-1a"]
+#  }
+#  workshop-b = {
+#    num_instances = 2
+#    azs_workers   = ["eu-west-1b"]
+#  }
+#}


### PR DESCRIPTION
+ Add the ability to build EKS clusters. Example:

```
eks_clusters = {
  workshop-a = {
    num_instances = 2
    azs_workers   = ["eu-west-1a"]
  }
  workshop-b = {
    num_instances = 2
    azs_workers   = ["eu-west-1b"]
  }
}
```

This block will produce 2 clusters in eu-west-1a and 2 cluster in eu-west-1b, for a total of 4 clusters.
In addition, a local folder 'output' is created with the kubeconfig of every cluster.
The creation is slow, this example took 12m:
![image](https://user-images.githubusercontent.com/35881711/123144190-b5138580-d45b-11eb-9fce-9d4c29d8c0da.png)

```
$ kubectl --kubeconfig=./output/jesus-test-workshop-b-2/kubeconfig-jesus-test-workshop-b-2 get nodes -A -owide
NAME                                       STATUS   ROLES    AGE     VERSION              INTERNAL-IP   EXTERNAL-IP    OS-IMAGE         KERNEL-VERSION                CONTAINER-RUNTIME
ip-10-0-2-108.eu-west-1.compute.internal   Ready    <none>   7m34s   v1.20.4-eks-6b7464   10.0.2.108    54.195.22.44   Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
```