### PR TITLE
gke_clusters

### DIFF
--- a/terraform/eks.auto.tfvars
+++ b/terraform/eks.auto.tfvars
@@ -1,0 +1,16 @@
+# EKS
+azs_controlplane   = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+azs_workers        = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+eks_version        = "1.20"
+node_instance_type = "t3.small"
+
+#eks_clusters = {
+#  workshop-a = {
+#    num_instances = 2
+#    azs_workers   = ["eu-west-1a"]
+#  }
+#  workshop-b = {
+#    num_instances = 2
+#    azs_workers   = ["eu-west-1b"]
+#  }
+#}

--- a/terraform/gce/gke/inputs.tf
+++ b/terraform/gce/gke/inputs.tf
@@ -1,0 +1,28 @@
+variable "gke_num_nodes" {
+  default     = 1
+  description = "number of gke nodes"
+}
+
+variable "project" {
+  description = "project"
+}
+
+variable "region" {
+  description = "region"
+}
+
+variable "zone" {
+  type = string
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "num_instances" {
+  type = string
+}
+
+variable "preemptible" {
+  type = bool
+}

--- a/terraform/gce/gke/main.tf
+++ b/terraform/gce/gke/main.tf
@@ -1,0 +1,102 @@
+# VPC
+resource "google_compute_network" "vpc" {
+  count                   = var.num_instances
+  project                 = var.project
+  name                    = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
+  auto_create_subnetworks = "false"
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  count         = var.num_instances
+  project       = var.project
+  name          = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
+  region        = var.region
+  network       = google_compute_network.vpc[count.index].name
+  ip_cidr_range = "10.10.0.0/24"
+}
+
+# GKE cluster
+resource "google_container_cluster" "primary" {
+  count    = var.num_instances
+  project  = var.project
+  name     = "${terraform.workspace}-${var.prefix}-${count.index + 1}"
+  location = var.zone
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network    = google_compute_network.vpc[count.index].name
+  subnetwork = google_compute_subnetwork.subnet[count.index].name
+
+  resource_labels = {
+    generated-by = "terraform"
+    workspace    = terraform.workspace
+    when         = lower(formatdate("MMM-DD-YYYY", timestamp()))
+  }
+
+  lifecycle {
+    ignore_changes = [
+      resource_labels,
+    ]
+  }
+}
+
+# Separately Managed Node Pool
+resource "google_container_node_pool" "primary_nodes" {
+  count      = var.num_instances
+  project    = var.project
+  name       = "${google_container_cluster.primary[count.index].name}-node-pool"
+  location   = var.zone
+  cluster    = google_container_cluster.primary[count.index].name
+  node_count = var.gke_num_nodes
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels = {
+      workspace = terraform.workspace
+      prefix    = var.prefix
+      instance  = 1
+    }
+
+    preemptible  = var.preemptible
+    machine_type = "n1-standard-1"
+    tags         = ["gke-node", "${terraform.workspace}-${var.prefix}-${count.index + 1}"]
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}
+
+resource "local_file" "kubeconfig" {
+  count = var.num_instances
+  content = templatefile("${path.module}/templates/kubeconfig.tpl", {
+    password               = "${google_container_cluster.primary[count.index].master_auth[0].password}"
+    username               = "${google_container_cluster.primary[count.index].master_auth[0].username}"
+    cluster_ca_certificate = "${google_container_cluster.primary[count.index].master_auth[0].cluster_ca_certificate}"
+    endpoint               = "${google_container_cluster.primary[count.index].endpoint}"
+    suffix                 = "${google_container_cluster.primary[count.index].name}"
+  })
+  filename = "${path.root}/output/gke/${google_container_cluster.primary[count.index].name}/original-kubeconfig"
+
+  provisioner "local-exec" {
+    command = <<COMMAND
+      cp ${path.root}/output/gke/${google_container_cluster.primary[count.index].name}/original-kubeconfig ${path.root}/output/gke/${google_container_cluster.primary[count.index].name}/full-kubeconfig \
+      && export KUBECONFIG=${path.root}/output/gke/${google_container_cluster.primary[count.index].name}/full-kubeconfig \
+      && kubectl apply -f ${path.module}/templates/gke-admin.yaml \
+      && TOKEN=$(kubectl describe -n kube-system secrets "$(kubectl describe -n kube-system serviceaccount gke-admin | grep -i Tokens | awk '{print $2}')" | grep token: | awk '{print $2}') \
+      && kubectl config set-credentials workshop --token=$TOKEN \
+      && kubectl config set-context workshop --cluster=${google_container_cluster.primary[count.index].name} --user=workshop \
+      && kubectl config use-context workshop \
+      && kubectl config view --flatten --minify > ${path.root}/output/gke/${google_container_cluster.primary[count.index].name}/guest-kubeconfig
+    COMMAND
+  }
+
+}

--- a/terraform/gce/gke/outputs.tf
+++ b/terraform/gce/gke/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  value       = google_container_cluster.primary.*.name
+  description = "GKE Cluster Name"
+}
+
+output "cluster_host" {
+  value       = google_container_cluster.primary.*.endpoint
+  description = "GKE Cluster Host"
+}

--- a/terraform/gce/gke/templates/gke-admin.yaml
+++ b/terraform/gce/gke/templates/gke-admin.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gke-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gke-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: gke-admin
+  namespace: kube-system

--- a/terraform/gce/gke/templates/kubeconfig.tpl
+++ b/terraform/gce/gke/templates/kubeconfig.tpl
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${cluster_ca_certificate}
+    server: https://${endpoint}
+  name: ${suffix}
+contexts:
+- context:
+    cluster: ${suffix}
+    user: ${suffix}
+  name: ${suffix}
+current-context: ${suffix}
+kind: Config
+preferences: {}
+users:
+- name: ${suffix}
+  user:
+    auth-provider:
+      name: gcp

--- a/terraform/gke.auto.tfvars
+++ b/terraform/gke.auto.tfvars
@@ -1,0 +1,10 @@
+# GKE
+region      = "europe-west4"
+preemptible = false
+
+#gke_clusters = {
+#  workshop-b = {
+#    num_instances = 1
+#    zone          = "europe-west4-a"
+#  }
+#}

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -10,6 +10,10 @@ variable "zone" {
   type = string
 }
 
+variable "region" {
+  type = string
+}
+
 variable "azs_controlplane" {
   type = list(string)
 }
@@ -36,10 +40,19 @@ variable "eks_clusters" {
   default = {}
 }
 
+variable "gke_clusters" {
+  type    = map(any)
+  default = {}
+}
+
 variable "eks_version" {
   type = string
 }
 
 variable "node_instance_type" {
   type = string
+}
+
+variable "preemptible" {
+  type = bool
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,3 +32,15 @@ module "eks-cluster" {
   eks_version        = lookup(each.value, "eks_version", var.eks_version)
   node_instance_type = lookup(each.value, "node_instance_type", var.node_instance_type)
 }
+
+module "gke-cluster" {
+  source   = "./gce/gke"
+  for_each = var.gke_clusters
+
+  prefix        = each.key
+  project       = lookup(each.value, "project", var.project)
+  region        = lookup(each.value, "region", var.region)
+  zone          = lookup(each.value, "zone", var.zone)
+  preemptible   = lookup(each.value, "preemptible", var.preemptible)
+  num_instances = lookup(each.value, "num_instances", var.num_instances)
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,3 +22,10 @@ output "eks_cluster" {
     for k, v in module.eks-cluster : k => v.cluster_name
   }
 }
+
+
+output "gke_cluster" {
+  value = {
+    for k, v in module.gke-cluster : k => v.cluster_name
+  }
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,12 +5,6 @@ zone          = "europe-west4-a"
 vm_image      = "ubuntu-2004-focal-v20210510"
 num_instances = 1
 
-#EKS
-azs_controlplane   = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-azs_workers        = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-eks_version        = "1.20"
-node_instance_type = "t3.small"
-
 # TO BE EDITED #
 environments = {
   #workshop1 = {
@@ -20,18 +14,7 @@ environments = {
   #  vm_image      = "ubuntu-2004-focal-v20210211"
   #}
   personal1 = {
-    num_instances = 1
+    num_instances = 0
     machine_type  = "n1-standard-8"
   }
 }
-
-#eks_clusters = {
-#  workshop-a = {
-#    num_instances = 2
-#    azs_workers   = ["eu-west-1a"]
-#  }
-#  workshop-b = {
-#    num_instances = 2
-#    azs_workers   = ["eu-west-1b"]
-#  }
-#}


### PR DESCRIPTION
+ Ability to build any number of GKE clusters, settings are in file `gke.auto.tfvars`
+ 3 kubeconfig are generated in folder `output`
  + `original-kubeconfig` This requires gcloud client and solo credentials
  + `guest-kubeconfig` This contains static credentials, good to be given to 3rd parties like workshop attendants
  + `full-kubeconfig` This contains both original+guest
+ EKS cluster configuration moved to file `eks.auto.tfvars`