### PR TITLE
eks_destroy_lb

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -29,21 +29,3 @@ eks_version        = "1.20"
 node_instance_type = "t3.small"
 include_vm         = {}
 
-environments = {
-  eks-workshop-base = {
-    num_instances = 0
-  }
-}
-
-eks_clusters = {
-  eks-1 = {
-    num_instances      = 3
-    node_instance_type = "t3.large"
-    include_vm = {
-      machine_type         = "n1-standard-1"
-      source_machine_image = "denis-eks-workshop-base-source-image"
-      region               = "europe-west1"
-      zone                 = "europe-west1-d"
-    }
-  }
-}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,17 +2,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.48.0"
+      version = "~> 3.50.0"
     }
-    helm = {
+    gcp = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.76.0"
     }
-    kubernetes = {
+    null-provider = {
       source  = "hashicorp/null"
       version = "~> 3.1.0"
     }
-    mysql = {
+    local-provider = {
       source  = "hashicorp/local"
       version = "~> 2.1.0"
     }


### PR DESCRIPTION
+ pv,pvc,svc are deleted before deleting the eks cluster, so finalizers will hopefully delete all external resources created, like EBS volumes and ELB in aws.