### PR TITLE
fix incorrect port for admin ui

### DIFF
--- a/gloo-portal/README.md
+++ b/gloo-portal/README.md
@@ -1491,7 +1491,7 @@ You can see the CSS below displayed on the right:
 }
 ```
 
-Go to the Admin UI (http://localhost:8000), click on `Portals` and then on the `E-commerce Portal`.
+Go to the Admin UI (http://localhost:8080), click on `Portals` and then on the `E-commerce Portal`.
 
 Click on the `Advanced Portal Customization` link and provide the CSS below:
 
@@ -1587,7 +1587,7 @@ It's very useful to provide additional information about your APIs, or even to l
 
 Static pages are very simple to add. You simply need to provide the content using the Markdown syntax.
 
-Go to the Admin UI (http://localhost:8000), click on `Portals` and then on the `E-commerce Portal`.
+Go to the Admin UI (http://localhost:8080), click on `Portals` and then on the `E-commerce Portal`.
 
 Click on the `Pages` tab and then on the `Add a Page` link.
 


### PR DESCRIPTION
In `Lab 4: Explore the Admin UI` the  Admin UI url is correctly referenced as `http://localhost:8080`.
But in `Lab 8: Portal rebranding` and `Lab 9: Extending the Portal` it is reference  as`http://localhost:8000`