### PR TITLE
Update deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,8 +77,8 @@ nodes:
   - containerPort: 6443
     hostPort: 70${twodigits}
 networking:
-  serviceSubnet: "10.0${twodigits}.0.0/16"
-  podSubnet: "10.1${twodigits}.0.0/16"
+  serviceSubnet: "10.${number}.0.0/16"
+  podSubnet: "10.1${number}.0.0/16"
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2


### PR DESCRIPTION
Script currently broken in kind version 0.14.0  . In serviceSubnet the second octet shows "001" which kind does not expect as valid. ERROR: failed to create cluster: invalid service subnet failed to parse cidr value:"10.001.0.0/16" with error: invalid CIDR address: 10.001.0.0/16