### PR TITLE
Add quotes in the appUrl definitation to fix copy and paste issue.

### DIFF
--- a/gloo-mesh-2-0-airgap/README.md
+++ b/gloo-mesh-2-0-airgap/README.md
@@ -3105,7 +3105,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3258,7 +3258,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-cilium/README.md
+++ b/gloo-mesh-2-0-cilium/README.md
@@ -3090,7 +3090,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3243,7 +3243,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-eks-and-openshift/README.md
+++ b/gloo-mesh-2-0-eks-and-openshift/README.md
@@ -3089,7 +3089,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3242,7 +3242,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-eks-single-workspace-no-revisions/README.md
+++ b/gloo-mesh-2-0-eks-single-workspace-no-revisions/README.md
@@ -2695,7 +2695,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -2848,7 +2848,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-eks/README.md
+++ b/gloo-mesh-2-0-eks/README.md
@@ -3001,7 +3001,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3154,7 +3154,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-gateway/README.md
+++ b/gloo-mesh-2-0-gateway/README.md
@@ -1412,7 +1412,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -1565,7 +1565,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-node-ports/README.md
+++ b/gloo-mesh-2-0-node-ports/README.md
@@ -3010,7 +3010,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3163,7 +3163,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-openshift/README.md
+++ b/gloo-mesh-2-0-openshift/README.md
@@ -3183,7 +3183,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3336,7 +3336,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-single-cluster-single-workspace-openshift-nodeport/README.md
+++ b/gloo-mesh-2-0-single-cluster-single-workspace-openshift-nodeport/README.md
@@ -1526,7 +1526,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -1679,7 +1679,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-single-cluster-single-workspace-openshift/README.md
+++ b/gloo-mesh-2-0-single-cluster-single-workspace-openshift/README.md
@@ -1535,7 +1535,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -1688,7 +1688,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-single-cluster-single-workspace/README.md
+++ b/gloo-mesh-2-0-single-cluster-single-workspace/README.md
@@ -1436,7 +1436,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -1589,7 +1589,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-single-cluster/README.md
+++ b/gloo-mesh-2-0-single-cluster/README.md
@@ -1757,7 +1757,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -1910,7 +1910,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0-single-workspace/README.md
+++ b/gloo-mesh-2-0-single-workspace/README.md
@@ -2686,7 +2686,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -2839,7 +2839,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-2-0/README.md
+++ b/gloo-mesh-2-0/README.md
@@ -3034,7 +3034,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:
@@ -3187,7 +3187,7 @@ spec:
       configs:
       - oauth2:
           oidcAuthorizationCode:
-            appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+            appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
             callbackPath: /callback
             clientId: ${KEYCLOAK_CLIENT}
             clientSecretRef:

--- a/gloo-mesh-airgap/README.md
+++ b/gloo-mesh-airgap/README.md
@@ -3479,7 +3479,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -3590,7 +3590,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:

--- a/gloo-mesh-all/README.md
+++ b/gloo-mesh-all/README.md
@@ -4716,7 +4716,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -4827,7 +4827,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:

--- a/gloo-mesh-eks-and-openshift/README.md
+++ b/gloo-mesh-eks-and-openshift/README.md
@@ -3415,7 +3415,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -3526,7 +3526,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:

--- a/gloo-mesh-eks/README.md
+++ b/gloo-mesh-eks/README.md
@@ -3363,7 +3363,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -3474,7 +3474,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:

--- a/gloo-mesh-openshift/README.md
+++ b/gloo-mesh-openshift/README.md
@@ -3459,7 +3459,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -3570,7 +3570,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:

--- a/gloo-mesh/README.md
+++ b/gloo-mesh/README.md
@@ -3512,7 +3512,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:
@@ -3624,7 +3624,7 @@ spec:
   configs:
   - oauth2:
       oidcAuthorizationCode:
-        appUrl: https://${ENDPOINT_HTTPS_GW_CLUSTER1}
+        appUrl: "https://${ENDPOINT_HTTPS_GW_CLUSTER1}"
         callbackPath: /callback
         clientId: ${client}
         clientSecretRef:


### PR DESCRIPTION
The copy and paste when creating a ExtAuthPolicy in the `Securing the access with OAuth` ends up creating a ExtAuthPolicy without the correctly substitued value for the `ENDPOINT_HTTPS_GW_CLUSTER1` appUrl.

```
k get ExtAuthPolicy --context $CLUSTER1 -n httpbin httpbin -oyaml                                                                                                                      ✔ │ at pszeto-cluster1-gke ⎈ │ at 02:19:00 PM 
apiVersion: security.policy.gloo.solo.io/v2
kind: ExtAuthPolicy
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"security.policy.gloo.solo.io/v2","kind":"ExtAuthPolicy","metadata":{"annotations":{},"name":"httpbin","namespace":"httpbin"},"spec":{"applyToRoutes":[{"route":{"labels":{"oauth":"true"}}}],"config":{"glooAuth":{"configs":[{"oauth2":{"oidcAuthorizationCode":{"appUrl":"https://$\\{ENDPOINT_HTTPS_GW_CLUSTER1\\}","callbackPath":"/callback","clientId":"eeb5c2e9-4a47-4fcf-97df-cca192913668","clientSecretRef":{"name":"oauth","namespace":"httpbin"},"headers":{"idTokenHeader":"jwt"},"issuerUrl":"http://34.121.47.249:8080/auth/realms/master/","scopes":["email"],"session":{"failOnFetchFailure":true,"redis":{"cookieName":"keycloak-session","options":{"host":"redis:6379"}}}}}},{"opaAuth":{"modules":[{"name":"allow-solo-email-users","namespace":"httpbin"}],"query":"data.test.allow == true"}}]},"server":{"cluster":"cluster1","name":"ext-auth-server","namespace":"httpbin"}}}}
  creationTimestamp: "2022-06-24T17:45:49Z"
  generation: 9
  name: httpbin
  namespace: httpbin
  resourceVersion: "804787"
  uid: a9b921c1-36c0-4f9a-93ed-ffbd4d6364f2
spec:
  applyToRoutes:
  - route:
      labels:
        oauth: "true"
  config:
    glooAuth:
      configs:
      - oauth2:
          oidcAuthorizationCode:
            appUrl: https://$\{ENDPOINT_HTTPS_GW_CLUSTER1\}
            callbackPath: /callback
            clientId: eeb5c2e9-4a47-4fcf-97df-cca192913668
            clientSecretRef:
              name: oauth
              namespace: httpbin
            headers:
              idTokenHeader: jwt
            issuerUrl: http://34.121.47.249:8080/auth/realms/master/
            scopes:
            - email
            session:
              failOnFetchFailure: true
              redis:
                cookieName: keycloak-session
                options:
                  host: redis:6379
      - opaAuth:
          modules:
          - name: allow-solo-email-users
            namespace: httpbin
          query: data.test.allow == true
    server:
      cluster: cluster1
      name: ext-auth-server
      namespace: httpbin
status:
  global:
    state: ACCEPTED
  selectedRoutes:
  - routeName: httpbin-httpbin
    routeTable:
      cluster: cluster1
      name: httpbin
      namespace: httpbin
```