### PR TITLE
Add note about Airplay Receiver port conflict

### DIFF
--- a/gloo-edge/README.md
+++ b/gloo-edge/README.md
@@ -105,6 +105,8 @@ To create a local Kubernetes cluster execute the script below:
 ./scripts/deploy.sh 1 gloo-edge
 ```
 
+> Note: If you are running this workshop on a Mac with AirPlay Receiver enabled, you may encounter a port conflict for port 5000. Disable AirPlay Receiver in your settings and run the command again.
+
 Then verify that your Kubernetes cluster is ready: 
 
 ```bash


### PR DESCRIPTION
Airplay Receiver runs on port 5000 and is on by default for most users. This results in a port conflict when setting up the kind cluster with the default settings. 

We could look to change the default port to something like 5001, but seeing port 5000 was referenced in a few places, I didn't want to break anything.

This PR adds a note for Mac users to save them some time figuring out where the port conflict is coming from.

