### PR TITLE
Revert "Update urls for instruqt"

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,18 +156,18 @@ const jsonTable3 = {
     {
       "Workshop": "Gloo Mesh Core",
       "default": [
-        { "text": "2.5", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/core-2-5-default" },
-        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/core-2-6-default" }
+        { "text": "2.5", "url": "https://play.instruqt.com/manage/soloio/tracks/core-2-5-default" },
+        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio/tracks/core-2-6-default" }
       ],
       "ambient": [
-        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/core-2-6-ambient" }
+        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio/tracks/core-2-6-ambient" }
       ]
     },
     {
       "Workshop": "Gloo Mesh Enterprise",
       "default": [
-        { "text": "2.5", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/enterprise-2-5-default" },
-        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/enterprise-2-6-default" }
+        { "text": "2.5", "url": "https://play.instruqt.com/manage/soloio/tracks/enterprise-2-5-default" },
+        { "text": "2.6", "url": "https://play.instruqt.com/manage/soloio/tracks/enterprise-2-6-default" }
       ],
     }
   ]
@@ -180,33 +180,33 @@ const jsonTable4 = {
     {
       "Workshop": "Gloo Edge",
       "default": [
-        { "text": "1.16", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/gloo-edge" }
+        { "text": "1.16", "url": "https://play.instruqt.com/manage/soloio/tracks/gloo-edge" }
       ],
     },
     {
       "Workshop": "Gloo Gateway Open Source",
       "default": [
-        { "text": "1.17", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-17-oss-default" },
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-oss-default" }
+        { "text": "1.17", "url": "https://play.instruqt.com/manage/soloio/tracks/1-17-oss-default" },
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-oss-default" }
       ],
     },
     {
       "Workshop": "Gloo Gateway Enterprise",
       "default": [
-        { "text": "1.17", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-17-enterprise-default" },
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-enterprise-default" }
+        { "text": "1.17", "url": "https://play.instruqt.com/manage/soloio/tracks/1-17-enterprise-default" },
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-enterprise-default" }
       ],
       "lambda": [
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-enterprise-lambda" }
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-enterprise-lambda" }
       ],
       "waypoint": [
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-waypoint-default" }
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-waypoint-default" }
       ],
       "virtual destination": [
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-gloo-mesh-vd-default" }
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-gloo-mesh-vd-default" }
       ],
       "ai": [
-        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio-technical-marketing/tracks/1-18-enterprise-ai-gateway-default" }
+        { "text": "1.18", "url": "https://play.instruqt.com/manage/soloio/tracks/1-18-enterprise-ai-gateway-default" }
       ],
     }
   ]


### PR DESCRIPTION
Reverts solo-io/workshops#280

Tagging @wendeh  -- there was a mix up with Instruqt and the soloio org is back where it was, so this change is not needed anymore. Sorry for the inconvenience. 